### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Github Docker Package Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.21
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: oam-dev/kubevela/vela-core
           username: ${{ github.actor }}
@@ -17,7 +17,7 @@ jobs:
           registry: docker.pkg.github.com
           tags: "latest"
       - name: Publish to Docker Hub Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.21
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: oamdev/vela-core
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           asset_name: sha256sums.txt
           asset_content_type: text/plain
       - name: Publish to Github Docker Package Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.21
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: oam-dev/kubevela/vela-core
           username: $GITHUB_ACTOR
@@ -101,7 +101,7 @@ jobs:
           registry: docker.pkg.github.com
           tags: "${{ steps.get_version.outputs.VERSION }}"
       - name: Publish to Docker Hub Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.21
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: oamdev/vela-core
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore